### PR TITLE
20220921 코딩 도장 : 콜라츠 추측

### DIFF
--- a/콜라츠추측/java/20220921/src/Solution.java
+++ b/콜라츠추측/java/20220921/src/Solution.java
@@ -1,0 +1,31 @@
+public class Solution {
+    public int solution(int num) {
+        long number = (long) num;
+        int answer = 0;
+
+        while (number != 1) {
+            answer += 1;
+
+            number = compute(number);
+
+            if (answer >= 500) {
+                answer = -1;
+                return answer;
+            }
+        }
+
+        return answer;
+    }
+
+    public long compute(long number) {
+        if (isEven(number)) {
+            return number / 2;
+        }
+
+        return number * 3 + 1;
+    }
+
+    public boolean isEven(long x) {
+        return x % 2 == 0;
+    }
+}

--- a/콜라츠추측/java/20220921/test/SolutionTest.java
+++ b/콜라츠추측/java/20220921/test/SolutionTest.java
@@ -1,0 +1,31 @@
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SolutionTest {
+
+    @Test
+    void isEven() {
+        Solution solution = new Solution();
+
+        assertTrue(solution.isEven(2));
+        assertFalse(solution.isEven(3));
+    }
+
+    @Test
+    void compute() {
+        Solution solution = new Solution();
+
+        assertEquals(3, solution.compute(6));
+        assertEquals(22, solution.compute(7));
+    }
+
+    @Test
+    void solution() {
+        Solution solution = new Solution();
+
+        assertEquals(0, solution.solution(1));
+        assertEquals(8, solution.solution(6));
+        assertEquals(-1, solution.solution(626331));
+    }
+}


### PR DESCRIPTION
## 요구 사항
- 1937년 Collatz란 사람에 의해 제기된 이 추측은, 주어진 수가 1이 될 때까지 다음 작업을 반복하면, 모든 수를 1로 만들 수 있다는 추측입니다. 작업은 다음과 같습니다.
```
1-1. 입력된 수가 짝수라면 2로 나눕니다. 
1-2. 입력된 수가 홀수라면 3을 곱하고 1을 더합니다. 
2. 결과로 나온 수에 같은 작업을 1이 될 때까지 반복합니다.
```
- 예를 들어, 주어진 수가 6이라면 6 → 3 → 10 → 5 → 16 → 8 → 4 → 2 → 1 이 되어 총 8번 만에 1이 됩니다. 
- 위 작업을 몇 번이나 반복해야 하는지 반환하는 함수, solution을 완성해 주세요.
- 단, 주어진 수가 1인 경우에는 0을, 작업을 500번 반복할 때까지 1이 되지 않는다면 –1을 반환해 주세요.


## 제약 조건
- 입력된 수, num은 1 이상 8,000,000 미만인 정수입니다.

## 결과 화면
![image](https://user-images.githubusercontent.com/65386533/191386911-1e4a7a0e-aac1-412a-b228-c754f22f1dc9.png)